### PR TITLE
Add impersonator repository as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "impersonator"]
+	path = impersonator
+	url = https://github.com/Barabazs/impersonator


### PR DESCRIPTION
Added https://github.com/Barabazs/impersonator as a submodule to track the original impersonator repository alongside the extension code.